### PR TITLE
Add per DB stats

### DIFF
--- a/redis-graphite.py
+++ b/redis-graphite.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
     Redis Graphite Publisher
     ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/redis-graphite.py
+++ b/redis-graphite.py
@@ -52,6 +52,14 @@ stats_keys = [
     # Stats
     ('total_connections_received', int),
     ('total_commands_processed', int),
+
+    # Keys
+    ('keyspace_hits', int),
+    ('keyspace_misses', int),
+
+    # Pubsub
+    ('pubsub_channels', int),
+    ('pubsub_patterns', int),
 ]
 
 parser = ArgumentParser()

--- a/redis-graphite.py
+++ b/redis-graphite.py
@@ -44,8 +44,8 @@ stats_keys = [
     ('mem_fragmentation_ratio', lambda x: int(float(x) * 100)),
 
     # Persistence
-    ('rdb_bgsave_in_progress', int), # Nice for graphites render 0 as inf
-    ('aof_rewrite_in_progress', int), # Nice for graphites render 0 as inf
+    ('rdb_bgsave_in_progress', int),  # Nice for graphites render 0 as inf
+    ('aof_rewrite_in_progress', int),  # Nice for graphites render 0 as inf
     ('aof_base_size', int),
     ('aof_current_size', int),
 
@@ -75,6 +75,7 @@ parser.add_argument('--once', '-o', help="Run only once, then quit", action="sto
 parser.add_argument('--interval', '-i', help="Check interval in seconds", type=int, default=10)
 parser.add_argument('--verbose', '-v', help="Debug output", action="store_true")
 
+
 def main():
     args = parser.parse_args()
 
@@ -82,11 +83,11 @@ def main():
         logging.basicConfig(level=logging.DEBUG)
 
     if isinstance(args.redis_ports, basestring):
-        args.redis_ports = [ args.redis_ports ]
+        args.redis_ports = [args.redis_ports]
     try:
         iter(args.redis_ports)
     except TypeError:
-        args.redis_ports = [ args.redis_ports ]
+        args.redis_ports = [args.redis_ports]
 
     log.debug("Starting mainloop")
 

--- a/redis-graphite.py
+++ b/redis-graphite.py
@@ -135,9 +135,6 @@ def main():
                         value = keytype(info[key])
                         if not send_metric(base_key + key, value, sock):
                             break
-                    else:
-                        continue
-                    break
 
                 if args.lists:
                     lists_key = base_key + "list."
@@ -145,15 +142,6 @@ def main():
                         length = client.llen(key)
                         if not send_metric(lists_key + key, length, sock):
                             break
-                    else:
-                        continue
-                    break
-
-            else:
-                log.debug("Sleeping {} seconds".format(args.interval))
-                time.sleep(args.interval)
-                continue
-            break
 
             if args.once:
                 sys.exit()

--- a/redis-graphite.py
+++ b/redis-graphite.py
@@ -71,6 +71,7 @@ parser.add_argument('--redis-ports', nargs='+', type=int, default=6379)
 parser.add_argument('--carbon-server', default="localhost")
 parser.add_argument('--carbon-port', type=int, default=2003)
 # Options
+parser.add_argument('--prefix', '-p', help="Prefix of stats, defaults to short hostname", default=None)
 parser.add_argument('--no-server-stats', '-s', help="Disable graphing of server stats", action="store_true")
 parser.add_argument('--lists', '-l', help="Watch the length of one or more lists", nargs="+")
 parser.add_argument('--dbinfo', '-d', help="Collect db size/expires/ttl info", action="store_true")
@@ -117,7 +118,9 @@ def main():
 
         while True:
             for redis_port in args.redis_ports:
-                base_key = "redis.{}:{}.".format(args.redis_server, redis_port)
+                if args.prefix is None:
+                    args.prefix = args.redis_server.split('.')[0]
+                base_key = "redis.{}:{}.".format(args.prefix, redis_port)
                 log.debug("Base key:{}".format(base_key))
 
                 log.debug("Connecting to redis")


### PR DESCRIPTION
Add `-d`, `--dbinfo` option to collect and send key stats per DB
Add `-p`, `--prefix` for customizing stats prefix (in lieu of hostname)
Abstracts metric sending

@DerMitch Hey there, have been using this to collect redis stats and had to add some bits today so thought I would kick it back. One thing that I wasn't grokking was the use of:

```
else:
    continue
break
```

at the end of loops. I read up on python's `for:... else` syntax but I'm still in the dark, and it was causing the other collectors (`args.lists`, `args.dbinfo`) to not fire, so I removed it. It still works in the cases of:

| redis | carbon |
| --- | --- |
| up | up |
| down | up |
| up | down |
| down | down |

so I think it's ok to remove, but wanted to ask if there was other logic in here.

Thanks for the script!
